### PR TITLE
Fixed kane benchmark for different input order

### DIFF
--- a/benchmarks/physics/mechanics/kane.py
+++ b/benchmarks/physics/mechanics/kane.py
@@ -24,12 +24,19 @@ class KanesMethodMassSpringDamper:
         # Create the list of kinematic differential equations, force list and
         # list of bodies/particles
         kd = [qd - u]
-        self.force_list = [(P, (-k * q - c * u) * N.x)]
-        self.body_list = [pa]
+        force_list = [(P, (-k * q - c * u) * N.x)]
+        body_list = [pa]
 
         # Create an instance of KanesMethod
         self.KM = me.KanesMethod(N, q_ind=[q], u_ind=[u], kd_eqs=kd)
 
+        # Account for the new method of input to kanes_equations
+        try:
+            self.KM.kanes_equations(body_list, force_list)
+            self.inputs = (body_list, force_list)
+        except TypeError:
+            self.inputs = (force_list, body_list)
+
     def time_kanesmethod_mass_spring_damper(self):
         # Create the equations of motion using kanes method
-        self.KM.kanes_equations(self.body_list, self.force_list)
+        self.KM.kanes_equations(self.inputs)


### PR DESCRIPTION
The input order for KanesMethod.kanes_equations() was switched. This
code should account for both input methods.

This should address issue #28 