### PR TITLE
Use numpy in default asv config (for lambdify etc.)

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -45,6 +45,7 @@
     "matrix": {
         "fastcache": [],
         "mpmath": [],
+        "numpy": [],
     },
 
     // The directory (relative to the current directory) that benchmarks are


### PR DESCRIPTION
I was bisecting a regression in `lambdify` (seen [here](https://github.com/symengine/symengine.py/pull/112)).
and found this result:
https://github.com/sympy/sympy/pull/11862/commits/2a459a2be47836f59714de35d4f32345d6c55eaa

But that was does not correspond to the earlier observation. I think it makes sense that the benchmarks are run with numpy present by default.

When NumPy is present, this is found to be the regressing commit:
https://github.com/sympy/sympy/pull/11468/commits/9365202e84d5ffab1aeec7b611bd69c03b0bae07
