### PR TITLE
Fix travis failing

### DIFF
--- a/benchmarks/tests/test_dsolve.py
+++ b/benchmarks/tests/test_dsolve.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import sympy
-from sympy import dsolve, Eq, exp
+from sympy import dsolve, Ne, exp
 
 from benchmarks.dsolve import _make_ode_01
 
@@ -9,8 +9,8 @@ def test_make_ode_01():
     ode, params = _make_ode_01()
     t, y, y0, k = params
     result = dsolve(ode, y[1](t))
-    eq_assumption = sympy.Q.is_true(Eq(k[1], k[0]))
-    refined = result.refine(~eq_assumption)
+    eq_assumption = sympy.Q.is_true(Ne(k[1], k[0]))
+    refined = result.refine(eq_assumption)
     ignore = k + y0 + (t,)
     int_const = [fs for fs in refined.free_symbols if fs not in ignore][0]
     ref = int_const*exp(-k[1]*t) - exp(-k[0]*t)*k[0]*y0[0]/(k[0] - k[1])

--- a/benchmarks/tests/test_integrate.py
+++ b/benchmarks/tests/test_integrate.py
@@ -17,8 +17,6 @@ def test_make_integral_01():
     refined_eq = integral.subs({l: k}).doit()
     assert (refined_eq - ref_eq).simplify() == 0
 
-    eq_assumption = sympy.Q.is_true(sympy.Eq(l, k))
-    refined_neq = sympy.refine(intgr, ~eq_assumption).simplify()
-    print(refined_neq)
-    print(ref_neq)
+    eq_assumption = sympy.Q.is_true(sympy.Ne(l, k))
+    refined_neq = sympy.refine(intgr, eq_assumption).simplify()
     assert (refined_neq - ref_neq).simplify() == 0


### PR DESCRIPTION
- Changed the assumptions used in refine
- Deleted print

I think there may be an issue for `refine` not considering `~Ne` as same as `Eq`