### PR TITLE
Remove uneeded imports for Python 3.8 and SymPy 1.6 compatibility

### DIFF
--- a/benchmarks/lambdify.py
+++ b/benchmarks/lambdify.py
@@ -1,4 +1,3 @@
-from time import clock
 import sympy as sp
 
 def _get_args_exprs():

--- a/benchmarks/logic.py
+++ b/benchmarks/logic.py
@@ -1,6 +1,5 @@
 import os
 
-from sympy.core.compatibility import range
 from sympy.logic.utilities import load_file
 from sympy.logic import satisfiable
 

--- a/benchmarks/tests/test_dsolve.py
+++ b/benchmarks/tests/test_dsolve.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import sympy
-from sympy import dsolve, Ne, exp
+from sympy import dsolve, Ne, exp, refine
 
 from benchmarks.dsolve import _make_ode_01
 
@@ -10,7 +10,7 @@ def test_make_ode_01():
     t, y, y0, k = params
     result = dsolve(ode, y[1](t))
     eq_assumption = sympy.Q.is_true(Ne(k[1], k[0]))
-    refined = result.refine(eq_assumption)
+    refined = refine(result, eq_assumption)
     ignore = k + y0 + (t,)
     int_const = [fs for fs in refined.free_symbols if fs not in ignore][0]
     ref = int_const*exp(-k[1]*t) - exp(-k[0]*t)*k[0]*y0[0]/(k[0] - k[1])

--- a/slow_benchmarks/tests/test_refine.py
+++ b/slow_benchmarks/tests/test_refine.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import sympy
-from sympy import dsolve, Eq, exp
+from sympy import dsolve, Eq, exp, refine
 
 from slow_benchmarks.refine import _mk_piecewise_01
 
@@ -10,7 +10,7 @@ def test_mk_piecewise_01():
     t, y, y0, k, C1 = params
     k0, k1 = k
     u0, v0 = y0
-    refined = eq.refine(~sympy.Q.is_true(Eq(k[1], k[0])))
+    refined = refine(eq, ~sympy.Q.is_true(Eq(k[1], k[0])))
     assert refined.lhs == y[1](t)
     ref_rhs = (C1 - k0*u0*exp(k1*t)/(k0*exp(k0*t) - k1*exp(k0*t)))*exp(-k1*t)
     assert refined.rhs == ref_rhs


### PR DESCRIPTION
The benchmarks don't currently work with Python 3.8 or SymPy master due to imports that no longer exist e.g.:
https://travis-ci.org/sympy/sympy/jobs/638843773?utm_medium=notification&utm_source=github_status

This removes two imports (that are not needed anyway) to fix that.