### PR TITLE
Add some basic benchmarks for Risch

### DIFF
--- a/benchmarks/integrate.py
+++ b/benchmarks/integrate.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import sympy
-from sympy import symbols, Integral, exp
+from sympy import symbols, Integral, exp, log, Add
 
 def _make_integral_01():
     # Scaled down version of an integration by parts example
@@ -42,3 +41,45 @@ class TimeIntegration01:
 
     def time_doit_meijerg(self):
         self.values['time_doit_meijerg'] = self.integral.doit(meijerg=True)
+
+
+class _TimeIntegrationRisch(object):
+    params = [1, 10, 100]
+
+    def setup(self, n):
+        x = symbols('x')
+        self.integral = Integral(self.make_expr(n), x)
+        self.values = {}
+
+    def teardown(self, n):
+        x = symbols('x')
+        for key, val in self.values.items():
+            ref = self.make_expr(n)
+            if (ref - val.diff(x)).simplify() != 0:
+                raise ValueError("Incorrect result, invalid timing:"
+                                     " %s != %s" % (ref, val))
+
+    def time_doit(self, n):
+        self.values['time_doit'] = self.integral.doit()
+
+    def time_doit_risch(self, n):
+        self.values['time_doit_risch'] = self.integral.doit(risch=True)
+
+
+class TimeIntegrationRisch01(_TimeIntegrationRisch):
+    def make_expr(self, n):
+        x = symbols('x')
+        expr = x**n*exp(x)
+        return expr
+
+class TimeIntegrationRisch02(_TimeIntegrationRisch):
+    def make_expr(self, n):
+        x = symbols('x')
+        expr = log(Add(*[exp(i*x) for i in range(n)])).diff(x)
+        return expr
+
+class TimeIntegrationRisch03(_TimeIntegrationRisch):
+    def make_expr(self, n):
+        x = symbols('x')
+        expr = Add(*[log(x)**i for i in range(n)])
+        return expr


### PR DESCRIPTION
There should be better benchmarks for the other algorithms too, but I didn't attempt to do that here. I also didn't attempt to refactor the other integration benchmarks code. 

One question is if these benchmarks are too slow. If they are, we can reduce the `100` parameter. 