### PR TITLE
Temp fix for test_mks_eqs equality operator bug

### DIFF
--- a/benchmarks/tests/test_solve.py
+++ b/benchmarks/tests/test_solve.py
@@ -14,8 +14,8 @@ def test_mk_eqs():
     y0, y1 = y
     sol = sympy.solve(eqs, *p.c)
     assert sol[p.c[2]] == y0[2]/2
-    assert sol[p.c[4]] == (p.x1**2*(3*y0[2] - 2*y1[2])/2 + p.x1*(8*y0[1] + 7*y1[1]) + 15*y0[0] - 15*y1[0])/p.x1**4
+    assert sol[p.c[4]].expand() == ((p.x1**2*(3*y0[2] - 2*y1[2])/2 + p.x1*(8*y0[1] + 7*y1[1]) + 15*y0[0] - 15*y1[0])/p.x1**4).expand()
     assert sol[p.c[0]] == y0[0]
-    assert sol[p.c[3]] == (p.x1**2*(-3*y0[2] + y1[2]) - 4*p.x1*(3*y0[1] + 2*y1[1]) - 20*y0[0] + 20*y1[0])/(2*p.x1**3)
-    assert sol[p.c[5]] == (p.x1**2*(-y0[2] + y1[2]) - 6*p.x1*(y0[1] + y1[1]) - 12*y0[0] + 12*y1[0])/(2*p.x1**5)
+    assert sol[p.c[3]].expand() == ((p.x1**2*(-3*y0[2] + y1[2]) - 4*p.x1*(3*y0[1] + 2*y1[1]) - 20*y0[0] + 20*y1[0])/(2*p.x1**3)).expand()
+    assert sol[p.c[5]].expand() == ((p.x1**2*(-y0[2] + y1[2]) - 6*p.x1*(y0[1] + y1[1]) - 12*y0[0] + 12*y1[0])/(2*p.x1**5)).expand()
     assert sol[p.c[1]] == y0[1]


### PR DESCRIPTION
Closes #86.

Applied .expand to fix this equality bug resulting in failed tests. 
This fix is a temporary fix and doesn't fix the root issue.