### PR TITLE
changed the value benchmarks: runs-on ubuntu 20.04 into ubuntu latest

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
working on PR#106, the CI cannot run the benchmark due to an old setting about the ubuntu version. 
changed to ubuntu-latest from ubuntu 20.04 to fix this problem