### PR TITLE
Add benchmark for symbolic matrix multiplication

### DIFF
--- a/benchmarks/matrix_multiply.py
+++ b/benchmarks/matrix_multiply.py
@@ -1,0 +1,8 @@
+class TimeMatrixMultiply:
+    def setup(self):
+        from sympy import Matrix, symbols
+        x = symbols('x')
+        self.A = Matrix([[x+i for i in range(30)] for j in range(30)])
+
+    def time_matrix_multiply(self):
+        self.A * self.A


### PR DESCRIPTION
This PR adds a benchmark for symbolic matrix multiplication using a 30x30 symbolic matrix. This helps monitor performance regressions in matrix operations.