### PR TITLE
Add benchmark for simplify on large expressions

### DIFF
--- a/benchmarks/simplify_large_expr.py
+++ b/benchmarks/simplify_large_expr.py
@@ -1,0 +1,12 @@
+import sympy as sp
+class TimeSimplifyLargeExpr:
+    params = [10, 20, 40]
+    param_names = ["n"]
+    def setup(self, n):
+        x = sp.symbols("x")
+        expr = 0
+        for i in range(1, n):
+            expr += sp.sin(x)**2 + sp.cos(x)**2
+        self.expr = expr
+    def time_simplify(self, n):
+        sp.simplify(self.expr)


### PR DESCRIPTION
Adds a parameterized benchmark measuring the performance of simplify on large symbolic expressions composed of trigonometric identities.