### PR TITLE
Add experimental snapshot runner PoC and asymptotic plot

### DIFF
--- a/experimental/snapshot_perf_harness/README.md
+++ b/experimental/snapshot_perf_harness/README.md
@@ -1,0 +1,98 @@
+# Snapshot-Style Performance Harness Demo
+
+This directory is a small proof of concept for the cold-cache benchmarking
+workflow described in my SymPy GSoC proposal. It is not meant to be a finished
+benchmark framework. It is meant to show that the core execution model already
+works in code.
+
+The current prototype demonstrates five things:
+
+- cold samples can be run in fresh worker processes
+- warm measurements can be separated from cold measurements
+- each configuration can be sampled repeatedly with independent workers
+- results can be stored as structured JSON rather than ad hoc terminal output
+- a small curated set of workload families can be run without changing the
+  runner core
+
+## Files
+
+- `cases.py`: case registry and workload definitions
+- `worker.py`: runs one isolated sample and emits JSON
+- `runner.py`: orchestrates repeated samples and summarizes them
+
+## What this PoC is proving
+
+The main point of this prototype is to show a measurement model that is closer
+to SymPy's cold-cache performance questions than a loop-based benchmark body.
+
+- In `cold` mode, each sample starts in a fresh Python process and times one
+  call.
+- In `warm` mode, each sample still gets its own worker process, but the worker
+  warms up first and then records repeated timed calls.
+- For each case/parameter/mode combination, the runner collects multiple
+  independent samples and summarizes them.
+
+The report treats the median as the primary statistic. That is deliberate: for
+small benchmark runs, median is usually a better headline number than a single
+sample or a raw mean.
+
+## Run it
+
+From the repo root:
+
+```bash
+python3 experimental/snapshot_perf_harness/runner.py \
+  --samples 3 \
+  --output experimental/snapshot_perf_harness/results/demo_report.json
+```
+
+Run one workload family across several parameter points:
+
+```bash
+python3 experimental/snapshot_perf_harness/runner.py \
+  --cases poly_mul \
+  --params 10 20 30 \
+  --modes cold warm
+```
+
+Inspect one worker directly:
+
+```bash
+python3 experimental/snapshot_perf_harness/worker.py \
+  --case poly_mul \
+  --param 10 \
+  --mode cold
+```
+
+## Current scope
+
+This prototype already includes:
+
+- fresh-process cold samples
+- one-execution cold timing
+- repeated independent sampling
+- summary statistics over raw samples
+- multiple parameter points, so the same case family can be used for basic
+  scaling studies
+- machine-readable JSON output with raw worker payloads
+
+This prototype does not yet include:
+
+- scheduled execution on a dedicated benchmark machine
+- baseline update or comparison workflows
+- plots, dashboards, or website output
+- integration with the existing benchmark repo infrastructure
+- a larger curated suite of real SymPy workloads
+
+## How I would cite it in the proposal
+
+I would describe this as a proposal companion prototype, not as a completed
+framework. The current code is enough to support these claims:
+
+- the parent/worker execution model is already implemented
+- cold and warm paths are already separated
+- repeatability is handled through repeated independent samples
+- stored JSON output is already available for later comparison work
+
+That is the level of evidence I want from a PoC: enough to show that the core
+design is real, without pretending that the full project has already been done.

--- a/experimental/snapshot_perf_harness/cases.py
+++ b/experimental/snapshot_perf_harness/cases.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from sympy import Poly, Symbol, exp, log, series, sin
+
+
+CaseRunner = Callable[[int], Any]
+
+
+@dataclass(frozen=True)
+class CaseDef:
+    case_id: str
+    label: str
+    default_params: tuple[int, ...]
+    run: CaseRunner
+    warmup_rounds: int = 2
+    repeat_rounds: int = 3
+
+
+def preview(result: Any, limit: int = 160) -> str:
+    text = " ".join(str(result).split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3]}..."
+
+
+def run_poly_mul(param: int) -> Any:
+    x = Symbol("x")
+    left = Poly((x + 1) ** param, x)
+    right = Poly((x - 1) ** param, x)
+    return left * right
+
+
+def run_composed_series(param: int) -> Any:
+    x = Symbol("x")
+    expr = exp(sin(x)) * log(1 + x)
+    return series(expr, x, 0, param)
+
+
+CASE_REGISTRY = {
+    "poly_mul": CaseDef(
+        case_id="poly_mul",
+        label="Multiply two Poly objects built from (x +/- 1)**N.",
+        default_params=(10, 20, 30),
+        run=run_poly_mul,
+    ),
+    "composed_series": CaseDef(
+        case_id="composed_series",
+        label="Expand exp(sin(x)) * log(1 + x) as a power series.",
+        default_params=(6, 8, 10),
+        run=run_composed_series,
+    ),
+}
+
+
+def get_case(case_id: str) -> CaseDef:
+    try:
+        return CASE_REGISTRY[case_id]
+    except KeyError as exc:
+        known = ", ".join(sorted(CASE_REGISTRY))
+        raise KeyError(f"Unknown case '{case_id}'. Known cases: {known}") from exc
+
+
+def list_case_ids() -> list[str]:
+    return sorted(CASE_REGISTRY)

--- a/experimental/snapshot_perf_harness/runner.py
+++ b/experimental/snapshot_perf_harness/runner.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from cases import get_case, list_case_ids
+
+
+ROOT = Path(__file__).resolve().parent
+WORKER = ROOT / "worker.py"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the snapshot-style benchmark demo.")
+    parser.add_argument(
+        "--cases",
+        nargs="+",
+        default=list_case_ids(),
+        choices=list_case_ids(),
+        help="Case ids to run.",
+    )
+    parser.add_argument(
+        "--modes",
+        nargs="+",
+        default=["cold", "warm"],
+        choices=("cold", "warm"),
+        help="Execution modes to run.",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=5,
+        help="Independent worker samples per case/param/mode.",
+    )
+    parser.add_argument(
+        "--params",
+        nargs="+",
+        type=int,
+        help="Optional override for all case parameters.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        help="Optional warmup override for warm samples.",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        help="Optional inner repeat override for warm samples.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSON output path for the full benchmark report.",
+    )
+    return parser.parse_args()
+
+
+def ns_to_ms(duration_ns: int | float) -> float:
+    return float(duration_ns) / 1_000_000.0
+
+
+def median_absolute_deviation(samples: list[int]) -> float:
+    median_value = statistics.median(samples)
+    deviations = [abs(sample - median_value) for sample in samples]
+    return float(statistics.median(deviations))
+
+
+def summarize_samples(samples: list[int]) -> dict[str, Any]:
+    median_value = int(statistics.median(samples))
+    minimum = min(samples)
+    maximum = max(samples)
+    mean = statistics.fmean(samples)
+    mad_ns = median_absolute_deviation(samples)
+    summary = {
+        "sample_count": len(samples),
+        "median_ns": median_value,
+        "mean_ns": mean,
+        "min_ns": minimum,
+        "max_ns": maximum,
+        "mad_ns": mad_ns,
+        "median_ms": ns_to_ms(median_value),
+        "mean_ms": ns_to_ms(mean),
+        "min_ms": ns_to_ms(minimum),
+        "max_ms": ns_to_ms(maximum),
+        "mad_ms": ns_to_ms(mad_ns),
+    }
+    if len(samples) > 1:
+        summary["stdev_ns"] = statistics.stdev(samples)
+        summary["stdev_ms"] = ns_to_ms(summary["stdev_ns"])
+    else:
+        summary["stdev_ns"] = 0.0
+        summary["stdev_ms"] = 0.0
+    return summary
+
+
+def run_worker(
+    case_id: str,
+    param: int,
+    mode: str,
+    warmup: int | None,
+    repeat: int | None,
+) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        str(WORKER),
+        "--case",
+        case_id,
+        "--param",
+        str(param),
+        "--mode",
+        mode,
+    ]
+    if warmup is not None:
+        command.extend(["--warmup", str(warmup)])
+    if repeat is not None:
+        command.extend(["--repeat", str(repeat)])
+
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        raise RuntimeError(
+            f"Worker produced no JSON output for case={case_id} param={param} mode={mode}.\n"
+            f"stderr:\n{completed.stderr}"
+        )
+
+    payload = json.loads(stdout)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Worker failed for case={case_id} param={param} mode={mode}:\n"
+            f"{payload.get('traceback', payload.get('error', stdout))}"
+        )
+    return payload
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "host_platform": platform.platform(),
+        "host_python": platform.python_version(),
+        "execution_model": {
+            "cold": "fresh process, one timed call",
+            "warm": "fresh process, warmup first, then take the median of repeated timed calls",
+        },
+        "repeatability_note": (
+            "Each case/param/mode is sampled with independent worker processes. "
+            "The primary summary statistic is the median."
+        ),
+        "primary_statistic": "median",
+        "samples_per_configuration": args.samples,
+        "cases": [],
+    }
+
+    for case_id in args.cases:
+        case = get_case(case_id)
+        params = tuple(args.params) if args.params else case.default_params
+        for param in params:
+            for mode in args.modes:
+                worker_payloads = []
+                sample_durations = []
+                for _ in range(args.samples):
+                    payload = run_worker(
+                        case_id=case_id,
+                        param=param,
+                        mode=mode,
+                        warmup=args.warmup,
+                        repeat=args.repeat,
+                    )
+                    worker_payloads.append(payload)
+                    sample_durations.append(payload["sample_duration_ns"])
+
+                summary = summarize_samples(sample_durations)
+                entry = {
+                    "case_id": case_id,
+                    "case_label": case.label,
+                    "param": param,
+                    "mode": mode,
+                    "summary": summary,
+                    "workers": worker_payloads,
+                }
+                report["cases"].append(entry)
+
+                print(
+                    f"[{mode:4}] {case_id:16} param={param:<4} "
+                    f"med={summary['median_ms']:.3f} ms "
+                    f"min={summary['min_ms']:.3f} ms "
+                    f"max={summary['max_ms']:.3f} ms"
+                )
+
+    return report
+
+
+def main() -> int:
+    args = parse_args()
+    if args.samples < 1:
+        raise SystemExit("--samples must be at least 1")
+
+    report = build_report(args)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"\nWrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experimental/snapshot_perf_harness/worker.py
+++ b/experimental/snapshot_perf_harness/worker.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import platform
+import statistics
+import sys
+import time
+import traceback
+from typing import Any
+
+from sympy import __version__ as sympy_version
+from sympy.core.cache import clear_cache
+
+from cases import get_case, list_case_ids, preview
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one benchmark sample.")
+    parser.add_argument("--case", required=True, choices=list_case_ids())
+    parser.add_argument("--param", required=True, type=int)
+    parser.add_argument("--mode", required=True, choices=("cold", "warm"))
+    parser.add_argument("--warmup", type=int)
+    parser.add_argument("--repeat", type=int)
+    return parser.parse_args()
+
+
+def measure_once(case: Any, param: int, clear_sympy_cache: bool) -> tuple[int, Any]:
+    gc.collect()
+    if clear_sympy_cache:
+        clear_cache()
+    start_ns = time.perf_counter_ns()
+    result = case.run(param)
+    end_ns = time.perf_counter_ns()
+    return end_ns - start_ns, result
+
+
+def run_sample(args: argparse.Namespace) -> dict[str, Any]:
+    case = get_case(args.case)
+    warmup_rounds = case.warmup_rounds if args.warmup is None else max(args.warmup, 0)
+    repeat_rounds = case.repeat_rounds if args.repeat is None else max(args.repeat, 1)
+
+    if args.mode == "cold":
+        duration_ns, result = measure_once(case, args.param, clear_sympy_cache=True)
+        inner_durations_ns = [duration_ns]
+        sample_duration_ns = duration_ns
+    else:
+        for _ in range(warmup_rounds):
+            case.run(args.param)
+
+        inner_durations_ns = []
+        result = None
+        for _ in range(repeat_rounds):
+            duration_ns, result = measure_once(
+                case, args.param, clear_sympy_cache=False
+            )
+            inner_durations_ns.append(duration_ns)
+        sample_duration_ns = int(statistics.median(inner_durations_ns))
+
+    return {
+        "case_id": case.case_id,
+        "case_label": case.label,
+        "param": args.param,
+        "mode": args.mode,
+        "pid": os.getpid(),
+        "python_version": platform.python_version(),
+        "sympy_version": sympy_version,
+        "platform": platform.platform(),
+        "warmup_rounds": warmup_rounds if args.mode == "warm" else 0,
+        "repeat_rounds": repeat_rounds if args.mode == "warm" else 1,
+        "sample_duration_ns": sample_duration_ns,
+        "inner_durations_ns": inner_durations_ns,
+        "result_type": type(result).__name__,
+        "result_preview": preview(result),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = run_sample(args)
+    except Exception as exc:  # noqa: BLE001
+        error_payload = {
+            "case_id": args.case,
+            "param": args.param,
+            "mode": args.mode,
+            "pid": os.getpid(),
+            "error": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+        print(json.dumps(error_payload))
+        return 1
+
+    print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

WIP: Custom math-aware benchmark runner with cache control (PoC)
#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
See #29094
See #111
Also see the https://groups.google.com/g/sympy/c/IIRI3ky0_EM/m/-JGizmhICgAJ

#### Brief description of what is fixed or changed
This PR introduces a small proof of concept for the cold-cache benchmarking workflow described in my SymPy GSoC proposal. It is not meant to be a finished benchmark framework. It is meant to show that the core execution model already works in code, providing a measurement model that is closer to SymPy's cold-cache performance questions than a standard loop-based benchmark body.

The current prototype demonstrates:
- cold samples can be run in fresh worker processes
- warm measurements can be separated from cold measurements
- each configuration can be sampled repeatedly with independent workers
- results can be stored as structured JSON rather than ad hoc terminal output
- a small curated set of workload families can be run without changing the runner core

In `cold` mode, each sample starts in a fresh Python process and times one call. In `warm` mode, each sample still gets its own worker process, but the worker warms up first and then records repeated timed calls. For each case/parameter/mode combination, the runner collects multiple independent samples and summarizes them. 

This is submitted as a proposal companion prototype to show that the core parent/worker execution model and data extraction flow are real and functional.

#### AI Generation Disclosure

Google gemini helped me write some repetitive code. Some code are generated by copilot inline suggestion.
