### PR TITLE
Add series and limit benchmarks with cache-aware variants

### DIFF
--- a/benchmarks/series.py
+++ b/benchmarks/series.py
@@ -1,0 +1,80 @@
+from sympy import symbols,oo, limit, sin, cos, exp, log, series,sqrt
+from sympy.core.cache import clear_cache
+x = symbols('x')
+
+# --- Limit benchmarks (warm cache) ---
+class TimeLimitWarmCache:
+
+    def time_limit_1_over_x(self):
+        limit(1/x, x, oo)
+
+    def time_limit_sin_x_over_x(self):
+        limit(sin(x)/x, x, 0)
+
+    def time_limit_exp(self):
+        limit((1 + 1/x)**x, x, oo)
+
+    def time_limit_log(self):
+        limit(log(x + 1)/log(x), x, oo)
+
+
+# --- Limit benchmarks (cold cache) ---
+class TimeLimitColdCache:
+    #Same limits but with cache cleared before each run.
+    #Shows realistic first-call performance users experience.
+
+    def setup(self):
+        clear_cache()
+
+    def time_limit_1_over_x(self):
+        clear_cache()
+        limit(1/x, x, oo)
+
+    def time_limit_sin_x_over_x(self):
+        clear_cache()
+        limit(sin(x)/x, x, 0)
+
+    def time_limit_exp(self):
+        clear_cache()
+        limit((1 + 1/x)**x, x, oo)
+
+    def time_limit_log(self):
+        clear_cache()
+        limit(log(x + 1)/log(x), x, oo)
+
+
+#Series expansion benchmarks
+class TimeSeriesExpansion:
+    #Series expansion benchmarks parameterized by order.
+
+    params = [5, 10, 20]
+    param_names = ['order']
+
+    def time_series_sin(self, order):
+        series(sin(x), x, 0, order)
+
+    def time_series_cos(self, order):
+        series(cos(x), x, 0, order)
+
+    def time_series_exp(self, order):
+        series(exp(x), x, 0, order)
+
+    def time_series_log_1_plus_x(self, order):
+        series(log(1 + x), x, 0, order)
+
+    def time_series_sqrt_1_plus_x(self, order):
+        series(sqrt(1 + x), x, 0, order)
+
+
+#Composite expression benchmarks
+class TimeSeriesComposite:
+    #Series of composed expressions.
+
+    def time_series_sin_exp(self):
+        series(sin(exp(x)), x, 0, 10)
+
+    def time_series_exp_sin(self):
+        series(exp(sin(x)), x, 0, 10)
+
+    def time_series_log_cos(self):
+        series(log(cos(x)), x, 0, 10)


### PR DESCRIPTION
Includes cold-cache benchmarks that measure realistic first-call performance, since ASV runs in a loop and only reports warm-cache time. See: https://github.com/sympy/sympy_benchmarks/issues/111

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See https://github.com/sympy/sympy_benchmarks/issues/111
See https://github.com/sympy/sympy/issues/21374

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Add benchmarks for series expansions and limit computations.
No series or limit benchmarks existed before in this repo.

Includes cache-aware variants (TimeLimitColdCache) that call
clear_cache() before each measurement. This addresses the concern
raised in #111 that ASV loop-based timing only reports warm-cache
results, which can be misleading for SymPy operations.

Benchmarks added:
- TimeLimitWarmCache: 4 limit benchmarks (standard)
- TimeLimitColdCache: 4 limit benchmarks with cache clearing
- TimeSeriesExpansion: 5 series benchmarks parameterized by order
- TimeSeriesComposite: 3 composed expression benchmarks


#### AI Generation Disclosure
I used AI for initial guidance on the benchmark structure
and understanding the ASV format. The final code was written by me
after studying the existing benchmarks in this repo.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
