### PR TITLE
Migrate Integer/Rational benchmarks from sympy to asv format

### DIFF
--- a/benchmarks/core/numbers.py
+++ b/benchmarks/core/numbers.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Benchmarks for SymPy numeric types: Integer, Rational, and utility functions.
+
+Migrated from sympy/core/benchmarks/bench_numbers.py.
+"""
+
+from sympy.core.numbers import Integer, Rational, pi, oo
+from sympy.core.intfunc import integer_nthroot, igcd
+from sympy.core.singleton import S
+
+# Shared instances — created once at module import time.
+i3 = Integer(3)
+i4 = Integer(4)
+r34 = Rational(3, 4)
+q45 = Rational(4, 5)
+
+
+class TimeInteger:
+    """Benchmarks for Integer arithmetic, conversion, and comparison."""
+
+    def time_create(self):
+        Integer(2)
+
+    def time_int_conversion(self):
+        int(i3)
+
+    def time_neg(self):
+        -i3
+
+    def time_neg_one(self):
+        -S.One
+
+    def time_abs(self):
+        abs(i3)
+
+    def time_abs_pi(self):
+        abs(pi)
+
+    def time_neg_oo(self):
+        -oo
+
+    def time_add_int(self):
+        i3 + 1
+
+    def time_add_Integer(self):
+        i3 + i4
+
+    def time_add_Rational(self):
+        i3 + r34
+
+    def time_sub(self):
+        i3 - i3
+
+    def time_mul_int(self):
+        i3 * 4
+
+    def time_mul_Integer(self):
+        i3 * i4
+
+    def time_mul_Rational(self):
+        i3 * r34
+
+    def time_eq_int(self):
+        i3 == 3
+
+    def time_eq_Rational(self):
+        i3 == r34
+
+
+class TimeRational:
+    """Benchmarks for Rational arithmetic."""
+
+    def time_add_int(self):
+        r34 + 1
+
+    def time_add_Rational(self):
+        r34 + q45
+
+
+class TimeNumberUtils:
+    """Benchmarks for integer utility functions: igcd and integer_nthroot."""
+
+    def time_igcd_coprime(self):
+        igcd(23, 17)
+
+    def time_igcd_multiple(self):
+        igcd(60, 3600)
+
+    def time_nthroot(self):
+        integer_nthroot(100, 2)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

See sympy/sympy#18097 

#### Brief description of what is fixed or changed

Migrates `bench_numbers.py` from `sympy/core/benchmarks/` to this repo in proper asv format.                                                       
                                                                                
The 20 original `timeit_` bare functions are reorganized into three benchmark classes:                                                                      
                                                            
- `TimeInteger` — creation, conversion, arithmetic, and comparison
- `TimeRational` — addition with int and Rational                             
- `TimeNumberUtils` — `igcd` and `integer_nthroot`
                                                                                
Source: `sympy/core/benchmarks/bench_numbers.py`

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE
