### PR TITLE
Added Solveset performance benchmark suite

### DIFF
--- a/benchmarks/solveset.py
+++ b/benchmarks/solveset.py
@@ -1,0 +1,102 @@
+from sympy.solvers.solveset import solveset
+from sympy.core.symbol import Symbol
+from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.trigonometric import sin, cos
+from sympy.functions.elementary.miscellaneous import root
+from sympy.core.singleton import S
+
+
+class TimeSolvesetPolynomial:
+    '''Benchmark for Solveset polynomial calculation'''
+
+    params = [1,5,10]
+
+    def setup(self,n):
+        self.x = Symbol ('x')
+        self.polynomial_eq = (self.x**(4*n)) - (self.x**(2*n)) + 1
+
+    def time_polynomial_solveset_complexes(self, n):
+        solveset(self.polynomial_eq, self.x, S.Complexes)
+
+    def time_polynomial_solveset_reals(self,n):
+        solveset(self.polynomial_eq, self.x, S.Reals)
+
+
+class TimeSolvesetTrigonometric:
+    '''Benchmark for Solveset Trigonometric functions calculation'''
+
+    # Trigonometric functions increase their time complexity non-linearly. We use small params to test them:
+    # param = 5 is an edge case (scaling from ~26ms to ~61ms), and param = 6 causes an ASV timeout.
+    params = [1,2,5]
+
+    def setup(self,n):
+        self.x = Symbol('x')
+        self.trigonometric_eq = sin(n * self.x) - cos(self.x)
+
+    def time_trigonometric_solveset(self,n):
+        solveset(self.trigonometric_eq, self.x)
+
+
+class TimeSolvesetExponential:
+    '''Benchmark for Solveset exponential functions calculation'''
+
+    # Solveset quickly returns an EmptySet when the domain is real.
+    # In contrast, evaluating infinite solutions in the complex domain takes significantly more time.
+    params = [1,5,10]
+
+    def setup(self,n):
+        self.x = Symbol ('x')
+        self.exponential_eq = exp(n * self.x) + 1
+
+    def time_exponential_solveset_complexes(self,n):
+        solveset(self.exponential_eq, self.x, S.Complexes)
+
+    def time_exponential_solveset_reals(self,n):
+        solveset(self.exponential_eq, self.x, S.Reals)
+
+
+class TimeSolvesetRational:
+    '''Benchmark for Solveset rational functions calculation'''
+
+    params = [1,5,10]
+
+    def setup(self,n):
+        self.x = Symbol('x')
+        self.rational_eq = (self.x**n - self.x - 1)/ (self.x - 2)
+
+    def time_rational_solveset_reals(self,n):
+        solveset(self.rational_eq, self.x, S.Reals)
+
+    def time_rational_solveset_complex(self,n):
+        solveset(self.rational_eq, self.x, S.Complexes)
+
+
+class TimeSolvesetIrrational:
+    '''Benchmark for Solveset irrational functions calculation'''
+
+    # When the domain is complex, param = 10 is an edge case: causes an ASV timeout.
+    # When the domain is real, solveset works perfectly and fast with every param.
+    params = [1,5,8]
+
+    def setup(self,n):
+        self.x = Symbol('x')
+        self.irrational_eq = root(self.x**n - self.x - 1, 4) + self.x
+
+    def time_irrational_solveset_real(self,n):
+        solveset(self.irrational_eq, self.x, S.Reals)
+
+    def time_irrational_solveset_complex(self,n):
+        solveset(self.irrational_eq, self.x, S.Complexes)
+
+
+class TimeSolvesetLogarithm:
+    '''Benchmark for Solveset logarithm functions calculation'''
+
+    params = [1,5,10]
+
+    def setup(self,n):
+        self.x = Symbol('x')
+        self.logarithm_eq = log(self.x**n) + log(self.x) - n
+
+    def time_logarithm_solveset(self,n):
+        solveset(self.logarithm_eq, self.x)

--- a/benchmarks/solveset.py
+++ b/benchmarks/solveset.py
@@ -27,7 +27,7 @@ class TimeSolvesetTrigonometric:
 
     # Trigonometric functions increase their time complexity non-linearly. We use small params to test them:
     # param = 5 is an edge case (scaling from ~26ms to ~61ms), and param = 6 causes an ASV timeout.
-    params = [1,2,5]
+    params = [1,3,5]
 
     def setup(self,n):
         self.x = Symbol('x')
@@ -74,9 +74,9 @@ class TimeSolvesetRational:
 class TimeSolvesetIrrational:
     '''Benchmark for Solveset irrational functions calculation'''
 
-    # When the domain is complex, param = 10 is an edge case: causes an ASV timeout.
+    # When the domain is complex, param = 7 is an edge case: causes an ASV timeout.
     # When the domain is real, solveset works perfectly and fast with every param.
-    params = [1,5,8]
+    params = [1,3,5]
 
     def setup(self,n):
         self.x = Symbol('x')


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixed Issue  #13
#### Brief description of what is fixed or changed
Added a comprehensive set of benchmarks that test `solveset` in various scenarios depending on the chosen mathematical function:

* `TimeSolvesetPolynomial` : Measures scaling for high-degree polynomials
* `TimeSolvesetTrigonometric` : Tests infinite set generation (ImageSet) for periodic equations. It uses the `sin` and `cos` functions.
* `TimeSolvesetExponential` : Compares performance between `S.Reals` (fast EmptySet return) and `S.Complexes`.
* `TimeSolvesetLogarithm` : Evaluates domain-specific overhead and logarithmic identity simplifications.
* `TimeSolvesetIrrational`: Tests radicals by forcing expression squaring.
* `TimeSolvesetLogarithm`: Tests logarithmic identities and domain limits.

Every function is tested with different params to analyze the time execution scaling.
#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used the AI for documentation purposes ; all code was authored and reviewed by me.
